### PR TITLE
A new kind of management.

### DIFF
--- a/src/main/java/org/jpokemon/api/Manager.java
+++ b/src/main/java/org/jpokemon/api/Manager.java
@@ -1,0 +1,31 @@
+package org.jpokemon.api;
+
+public interface Manager<T> {
+	
+	/**
+	 * Registers the object with the manager so it can be looked up by name.
+	 * 
+	 * @param managed The object to be registered.
+	 * 
+	 * @return `true` if the object is in fact registered; otherwise `false`.
+	 *
+	 * @throws JPokemonError if there is an error registering the object.
+	 */
+	public boolean register(T managed) throws JPokemonError;
+
+	/**
+	 * Checks if an item is registered with the manager.
+	 *
+	 * @return `true` if the item is known to the manager.
+	 */
+	public boolean isRegistered(T managed);
+
+	/**
+	 * Gets an item registered by this manager by name.
+	 * 
+	 * @param  name The name of the item requested.
+	 * 
+	 * @return      The {@link Item} instance for this item.
+	 */
+	public T getByName(String name);
+}

--- a/src/main/java/org/jpokemon/api/SimpleManager.java
+++ b/src/main/java/org/jpokemon/api/SimpleManager.java
@@ -1,0 +1,103 @@
+package org.jpokemon.api;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import java.util.TreeMap;
+
+/**
+ * Provides object management and lookup functionality. In order for this class 
+ * to function, the object T must have (a) a field "manager" of type Manager<T>,
+ * and (b) a method "getName()" that will return a unique identifier.
+ *
+ * @note This class uses reflection. Consider that a warning.
+ *
+ * @author atheriel@gmail.com
+ *
+ * @since  0.1
+ */
+public class SimpleManager<T> implements Manager<T> {
+	private final TreeMap<String, T> objectMap = new TreeMap<String, T>();
+	private final Class<T> managedClass; // Fucking type erasure...
+
+	/**
+	 * Due to type erasure, the class of the managed object needs to be passed 
+	 * to the manager during construction. This isn't the only possible solution
+	 * to this problem, but it is the simplest.
+	 * 
+	 * @param managedClass The class of the managed object.
+	 *
+	 * @throws JPokemonError if there is a conflict over object management.
+	 */
+	public SimpleManager(Class<T> managedClass) throws JPokemonError {		
+		this.managedClass = managedClass;
+		
+		// If the object has a "manager" field, set it to this; check for conflicts
+		try {
+			Field manager = managedClass.getField("manager");
+			if (manager.get(null) != null) {
+				throw new JPokemonError("This object already has a defined manager!");
+			} else {
+				manager.set(null, this);
+			}
+		} catch (IllegalAccessException e1) {
+		} catch (NoSuchFieldException e2) {
+		}
+	}
+	
+	/**
+	 * Registers the object with the manager so it can be looked up by name.
+	 * 
+	 * @param managed The object to be registered.
+	 * 
+	 * @return `true` if the object is in fact registered; otherwise `false`.
+	 *
+	 * @throws JPokemonError if there is an error registering the object.
+	 */
+	public boolean register(T managed) throws JPokemonError {
+		if (objectMap.containsValue(managed)) {
+			throw new JPokemonError("This object is already registered!");
+		}
+
+		// Get the name
+		String name = null;
+		try {
+			Method getName = managedClass.getMethod("getName");
+			name = (String) getName.invoke(managed);
+		} catch (Exception e) {
+		}
+
+		// Use the name to register, and check that it does not conflict
+		if (name == null) {
+			throw new JPokemonError("The object does not have a name to register under!");
+		} else if (objectMap.containsKey(name)) {
+			throw new JPokemonError("A object with the name " + name + " has already been registered!");
+		} else {
+			objectMap.put(name, managed);
+			return true;
+		}
+	}
+
+	/**
+	 * Checks if an object is registered with the manager.
+	 *
+	 * @return `true` if the object is known to the manager.
+	 */
+	public boolean isRegistered(T managed) {
+		return objectMap.containsValue(managed);
+	}
+
+	/**
+	 * Gets an object registered by this manager by name.
+	 * 
+	 * @param  name The name of the object requested.
+	 * 
+	 * @return The object by this name, or `null` if it does not exist.
+	 */
+	public T getByName(String name) {
+		if (!objectMap.containsKey(name)) {
+			return null;
+		}
+		return objectMap.get(name);
+	}
+}

--- a/src/main/java/org/jpokemon/api/types/PokemonType.java
+++ b/src/main/java/org/jpokemon/api/types/PokemonType.java
@@ -5,11 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jpokemon.api.Manager;
+
 /**
  * Defines a Pokémon type (such as Grass or Dark). For convenience, the classic
  * 17 types are instantiated by the {@link ClassicTypes} class.
  * 
- * If a {@link TypeManager} has been defined, calling {@link #setName} will
+ * If a {@link Manager} has been defined, calling {@link #setName} will
  * automatically register it with the manager under that name.
  * 
  * @author atheriel@gmail.com
@@ -17,7 +19,7 @@ import java.util.Map;
  * 
  * @since  0.1
  * 
- * @see TypeManager
+ * @see Manager
  * @see ClassicTypes
  */
 public class PokemonType {
@@ -25,7 +27,7 @@ public class PokemonType {
 	 * Indicates the manager that registers types; must be set before types can 
 	 * be instantiated.
 	 */
-	public static TypeManager manager = null;
+	public static Manager<PokemonType> manager = null;
 
 	/** Indicates the name of the type. */
 	protected String name;
@@ -49,7 +51,7 @@ public class PokemonType {
 	public PokemonType setName(String name) {
 		this.name = name;
 		if (manager != null) {
-			manager.registerType(this);
+			manager.register(this);
 		}
 		return this;
 	}

--- a/src/test/java/org/jpokemon/api/ManagerTest.java
+++ b/src/test/java/org/jpokemon/api/ManagerTest.java
@@ -1,0 +1,67 @@
+package org.jpokemon.api;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jpokemon.api.JPokemonError;
+import org.jpokemon.api.Manager;
+import org.jpokemon.api.SimpleManager;
+import org.jpokemon.api.types.PokemonType;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests the management of classes. This test uses the PokemonType class as an 
+ * example of a managed class.
+ * 
+ * @author atheriel@gmail.com
+ */
+@RunWith(JUnit4.class)
+public class ManagerTest {
+	static SimpleManager<PokemonType> manager;
+	static PokemonType type;
+
+	@BeforeClass
+	public static void setup() {
+		type = new PokemonType();
+		manager = new SimpleManager<PokemonType>(PokemonType.class);
+		type.setName("TestType"); // automatically registers it
+	}
+
+	/**
+	 * Verifies that only a single manager can be defined for a managed class.
+	 */
+	@Test(expected = JPokemonError.class)
+	public void testEnforcedSingleManagement() {
+		SimpleManager<PokemonType> manager2 = new SimpleManager<PokemonType>(PokemonType.class);
+	}
+
+	/**
+	 * Checks if an object can be properly registered.
+	 */
+	@Test
+	public void testManagement() {
+		assertTrue(manager.isRegistered(type));
+		assertTrue(manager.getByName("TestType") == type);
+	}
+
+	/**
+	 * Checks that only one object may be registered under a given name.
+	 */
+	@Test(expected = JPokemonError.class)
+	public void testManagementConflicts() {
+		PokemonType type2 = new PokemonType();
+		type2.setName("TestType"); // automatically registers it
+	}
+
+	/**
+	 * Checks that only objects with names can be registered.
+	 */
+	@Test(expected = JPokemonError.class)
+	public void testNameRequirement() {
+		PokemonType type2 = new PokemonType();
+		manager.register(type2);
+	}
+}


### PR DESCRIPTION
@zachtaylor 

It seems like the repo is filling up with AbilityManager/NatureManager/([A-Za-z]+)Manager classes as it becomes apparent that everything that can be managed in this fashion should be managed in this fashion.

I took a stab at abstracting all of these away. The new `SimpleManager<T>` class should be able to automatically register and keep track of any object that has both a
1. `manager` field of type `Manager<T>`; and
2. `getName` method that returns a non-null `String`

There's an example of its usage in the `ManagerTest` class. Let me know what you think.
